### PR TITLE
🚩 Add optional `std` feature, which is enabled by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,10 @@ edition = "2021"
 rust-version = "1.68"
 
 [features]
-default = ["serde", "cargo-toml", "simd"]
+default = ["serde", "cargo-toml", "simd", "std"]
 cargo-toml = ["serde"]
 simd = ["winnow/simd"]
+std = ["winnow/std", "serde?/std"]
 
 [dependencies]
 winnow = { version = "0.6.20", default-features = false, features = ["alloc"] }

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Build Status](https://github.com/zeenix/tomling/actions/workflows/rust.yml/badge.svg)](https://github.com/zeenix/tomling/actions/workflows/rust.yml) [![API Documentation](https://docs.rs/tomling/badge.svg)](https://docs.rs/tomling/) [![crates.io](https://img.shields.io/crates/v/tomling)](https://crates.io/crates/tomling)
 
-`tomling` is a `no_std` simple TOML parser API, that is designed to have minimal dependencies and is
-`no_std` compatible. The main target is Cargo manifests (`Cargo.toml` files) and hence why specific
+`tomling` is a simple TOML parser API, that is designed to have minimal dependencies and is `no_std`
+compatible. The main target is Cargo manifests (`Cargo.toml` files) and hence why specific
 API is provided for that purpose as well.
 
 ## Usage
@@ -138,6 +138,8 @@ path = "src/bin/my-binary.rs"
 - `serde` - Enables Serde support.
 - `cargo-toml` - Enables Cargo manifest specific API. This requires `serde`.
 - `simd` - Enables the `simd` feature of `winnow` for SIMD acceleration for parsing.
+- `std` - Enables some features, like `std::error::Error` implementation for `Error` type. It also
+  enables `std` feature of `winnow` and `serde`.
 
 All features are enabled by default.
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -62,6 +62,7 @@ impl std::error::Error for ParseError {
     }
 }
 
+#[cfg(feature = "serde")]
 #[derive(Debug, Clone, PartialEq)]
 pub struct DeserializeError {
     pub(crate) de: serde::de::value::Error,
@@ -83,6 +84,7 @@ impl From<serde::de::value::Error> for Error {
     }
 }
 
+#[cfg(feature = "serde")]
 impl alloc::fmt::Display for DeserializeError {
     fn fmt(&self, f: &mut alloc::fmt::Formatter<'_>) -> alloc::fmt::Result {
         write!(f, "{}", self.de)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 #![forbid(unsafe_code)]
 #![deny(
     missing_debug_implementations,


### PR DESCRIPTION
Which currently means implementation of `std::error::Error` for `Error` when this feature is enabled.