### PR TITLE
✅ Wire up `toml-test-harness` test suite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,285 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "bstr"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a68f1f47cdf0ec8ee4b941b2eee2a80cb796db73118c0dd09ac63fbe405be22"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "escape8259"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5692dd7b5a1978a5aeb0ce83b7655c58ca8efdcb79d21036ea249da95afec2c6"
+
+[[package]]
+name = "globset"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f1ce686646e7f1e19bf7d5533fe443a45dbfb990e00629110797578b42fb19"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "ignore"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itoa"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "540654e97a3f4470a492cd30ff187bc95d89557a903a2bbf112e2fae98104ef2"
+
+[[package]]
+name = "libc"
+version = "0.2.164"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
+
+[[package]]
+name = "libtest-mimic"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc0bda45ed5b3a2904262c1bb91e526127aa70e7ef3758aba2ef93cf896b9b58"
+dependencies = [
+ "clap",
+ "escape8259",
+ "termcolor",
+ "threadpool",
+]
+
+[[package]]
+name = "log"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -24,6 +299,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -47,6 +354,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.133"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,10 +383,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
+name = "toml-test"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9e26681e9154ffb40044019b6bb374f6ed7fef1e367d3d314f0daf2b00faba9"
+dependencies = [
+ "chrono",
+ "ryu",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "toml-test-data"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13bb6bf962107303ade738a8f729f4f92c29b2d84c0772cc376f7001602afa1a"
+dependencies = [
+ "include_dir",
+]
+
+[[package]]
+name = "toml-test-harness"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad65271b9325d4727b1afb346e2eb4cade8e998797682da4e73b7b6d902f2b2"
+dependencies = [
+ "ignore",
+ "libtest-mimic",
+ "toml-test",
+ "toml-test-data",
+]
+
+[[package]]
 name = "tomling"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "toml-test-harness",
  "winnow",
 ]
 
@@ -70,6 +447,104 @@ name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ serde = { version = "1.0.215", default-features = false, optional = true, featur
     "derive",
     "alloc",
 ] }
+
+[dev-dependencies]
+toml-test-harness = "0.4.10"

--- a/tests/toml_test.rs
+++ b/tests/toml_test.rs
@@ -1,0 +1,168 @@
+use std::collections::HashMap;
+
+use toml_test_harness::{Decoded, Decoder, DecoderHarness};
+use tomling::{parse, Table, Value};
+
+#[derive(Clone, Copy)]
+struct Tomling;
+
+impl Decoder for Tomling {
+    fn name(&self) -> &str {
+        "tomling"
+    }
+
+    fn decode(&self, data: &[u8]) -> Result<Decoded, toml_test_harness::Error> {
+        fn inner(data: &[u8]) -> Result<Decoded, Box<dyn std::error::Error>> {
+            let s = std::str::from_utf8(data)?;
+            let table = parse(s)?;
+            let table = map_table(&table);
+            Ok(Decoded::Table(table))
+        }
+
+        inner(data).map_err(toml_test_harness::Error::new)
+    }
+}
+
+fn map_table(table: &Table<'_>) -> HashMap<String, Decoded> {
+    table
+        .iter()
+        .map(|(key, val)| (key.to_owned(), value_to_decoded(val)))
+        .collect()
+}
+
+fn value_to_decoded(value: &Value<'_>) -> Decoded {
+    match value {
+        &Value::String(s) => Decoded::Value(s.into()),
+        &Value::Integer(i) => Decoded::Value(i.into()),
+        &Value::Float(f) => Decoded::Value(f.into()),
+        &Value::Boolean(b) => Decoded::Value(b.into()),
+        Value::Array(a) => Decoded::Array(a.iter().map(value_to_decoded).collect()),
+        Value::Table(t) => Decoded::Table(map_table(t)),
+    }
+}
+
+#[test]
+fn toml_test_harness() {
+    let mut harness = DecoderHarness::new(Tomling);
+    harness.version("1.0.0");
+    harness
+        .ignore([
+            "/invalid/array/extend*",
+            "/invalid/array/tables-*",
+            "/invalid/control/bare-cr.toml",
+            "/invalid/control/comment-*",
+            "/invalid/control/multi-*",
+            "/invalid/control/rawmulti-*",
+            "/invalid/control/rawstring-*",
+            "/invalid/control/string-*",
+            "/invalid/float/leading-zero.toml",
+            "/invalid/inline-table/duplicate-key-1.toml",
+            "/invalid/inline-table/overwrite-01.toml",
+            "/invalid/inline-table/overwrite-02.toml",
+            "/invalid/inline-table/overwrite-03.toml",
+            "/invalid/inline-table/overwrite-04.toml",
+            "/invalid/inline-table/overwrite-05.toml",
+            "/invalid/inline-table/overwrite-09.toml",
+            "/invalid/integer/leading-zero-1.toml",
+            "/invalid/integer/leading-zero-2.toml",
+            "/invalid/key/after-*",
+            "/invalid/key/dotted-redefine-table-*",
+            "/invalid/key/duplicate-keys-*",
+            "/invalid/key/newline-2.toml",
+            "/invalid/key/newline-3.toml",
+            "/invalid/key/no-eol.toml",
+            "/invalid/key/special-character.toml",
+            "/invalid/spec/inline-table-*",
+            "/invalid/spec/table-9-*",
+            "/invalid/string/bad-byte-escape.toml",
+            "/invalid/string/bad-escape-*",
+            "/invalid/string/bad-hex-esc-*",
+            "/invalid/string/bad-multiline.toml",
+            "/invalid/string/bad-slash-escape.toml",
+            "/invalid/string/bad-uni-esc-*",
+            "/invalid/string/basic-byte-escapes.toml",
+            "/invalid/string/basic-multiline-out-of-range-unicode-escape-*",
+            "/invalid/string/basic-multiline-unknown-escape.toml",
+            "/invalid/string/basic-out-of-range-unicode-escape-*",
+            "/invalid/string/basic-unknown-escape.toml",
+            "/invalid/string/multiline-bad-escape-*",
+            "/invalid/string/multiline-escape-space-*",
+            "/invalid/table/append-to-array-with-dotted-keys.toml",
+            "/invalid/table/append-with-dotted-keys-*",
+            "/invalid/table/array-implicit.toml",
+            "/invalid/table/duplicate*",
+            "/invalid/table/overwrite-*",
+            "/invalid/table/redefine-*",
+            "/invalid/table/super-twice.toml",
+            "/valid/array/array-subtables.toml",
+            "/valid/array/array.toml",
+            "/valid/array/mixed-string-table.toml",
+            "/valid/array/nested-double.toml",
+            "/valid/array/open-parent-table.toml",
+            "/valid/array/string-quote-comma*",
+            "/valid/array/string-with-comma*",
+            "/valid/array/table-array-string-backslash.toml",
+            "/valid/comment/after-literal-no-ws.toml",
+            "/valid/comment/everywhere.toml",
+            "/valid/comment/noeol.toml",
+            "/valid/comment/tricky.toml",
+            "/valid/datetime",
+            "/valid/empty-file.toml",
+            "/valid/example.toml",
+            "/valid/float",
+            "/valid/inline-table/empty.toml",
+            "/valid/inline-table/key-dotted-*",
+            "/valid/integer",
+            "/valid/key/escapes.toml",
+            "/valid/key/quoted-unicode.toml",
+            "/valid/key/space.toml",
+            "/valid/spec-example-1-compact.toml",
+            "/valid/spec-example-1.toml",
+            "/valid/spec/array-0.toml",
+            "/valid/spec/array-1.toml",
+            "/valid/spec/array-of-tables-1.toml",
+            "/valid/spec/float-*",
+            "/valid/spec/inline-table-0.toml",
+            "/valid/spec/integer-*",
+            "/valid/spec/local-*",
+            "/valid/spec/offset-date-time-*",
+            "/valid/spec/string-0.toml",
+            "/valid/spec/string-2.toml",
+            "/valid/spec/string-3.toml",
+            "/valid/spec/string-4.toml",
+            "/valid/spec/string-7.toml",
+            "/valid/spec/table-0.toml",
+            "/valid/spec/table-3.toml",
+            "/valid/spec/table-4.toml",
+            "/valid/spec/table-5.toml",
+            "/valid/spec/table-6.toml",
+            "/valid/spec/table-7.toml",
+            "/valid/string/double-quote-escape.toml",
+            "/valid/string/ends-in-whitespace-escape.toml",
+            "/valid/string/escape-tricky.toml",
+            "/valid/string/escaped-escape.toml",
+            "/valid/string/escapes.toml",
+            "/valid/string/multiline-empty.toml",
+            "/valid/string/multiline-escaped-crlf.toml",
+            "/valid/string/multiline-quotes.toml",
+            "/valid/string/multiline.toml",
+            "/valid/string/nl.toml",
+            "/valid/string/quoted-unicode.toml",
+            "/valid/string/raw-multiline.toml",
+            "/valid/string/start-mb.toml",
+            "/valid/string/unicode-escape.toml",
+            "/valid/table/array-implicit*",
+            "/valid/table/array-nest.toml",
+            "/valid/table/array-table-array.toml",
+            "/valid/table/array-within-dotted.toml",
+            "/valid/table/empty.toml",
+            "/valid/table/keyword.toml",
+            "/valid/table/names.toml",
+            "/valid/table/no-eol.toml",
+            "/valid/table/sub-empty.toml",
+            "/valid/table/whitespace.toml",
+            "/valid/table/without-super.toml",
+        ])
+        .unwrap();
+    harness.test();
+}


### PR DESCRIPTION
Resolves #6

Wires up the test suite and ignores all of the tests that aren't currently passing (although it looks like there's some low-hanging fruit)