### PR TITLE
✨ Add `Value` helpers and trait impls

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,34 +85,20 @@ assert_eq!(binary.path(), Some("src/bin/my-binary.rs"));
 // Using the generic raw `TOML` parsing API:
 //
 let manifest = parse(CARGO_TOML).unwrap();
-let package = match manifest.get("package").unwrap() {
-    Value::Table(package) => package,
-    _ => panic!(),
-};
-assert_eq!(package.get("name").unwrap(), &Value::String("example".into()));
-assert_eq!(package.get("version").unwrap(), &Value::String("0.1.0".into()));
-assert_eq!(package.get("edition").unwrap(), &Value::String("2021".into()));
-assert_eq!(package.get("resolver").unwrap(), &Value::String("2".into()));
+let package = manifest.get("package").unwrap().as_table().unwrap();
+assert_eq!(package.get("name").unwrap().as_str().unwrap(), "example");
+assert_eq!(package.get("version").unwrap().as_str().unwrap(), "0.1.0");
+assert_eq!(package.get("edition").unwrap().as_str().unwrap(), "2021");
+assert_eq!(package.get("resolver").unwrap().as_str().unwrap(), "2");
 
-let deps = match manifest.get("dependencies").unwrap() {
-    Value::Table(deps) => deps,
-    _ => panic!(),
-};
-let serde = match deps.get("serde").unwrap() {
-    Value::Table(serde) => serde,
-    _ => panic!(),
-};
-assert_eq!(serde.get("version").unwrap(), &Value::String("1.0".into()));
-let serde_features = match serde.get("features").unwrap() {
-    Value::Array(features) => features.as_slice(),
-    _ => panic!(),
-};
-assert_eq!(serde_features, &[Value::String("std".into()), Value::String("derive".into())]);
-let regex = match deps.get("regex").unwrap() {
-    Value::String(regex) => regex,
-    _ => panic!(),
-};
-assert_eq!(&*regex, "1.5");
+let deps = manifest.get("dependencies").unwrap().as_table().unwrap();
+let serde = deps.get("serde").unwrap().as_table().unwrap();
+assert_eq!(serde.get("version").unwrap().as_str().unwrap(), "1.0");
+let serde_features =
+    serde.get("features").unwrap().as_array().unwrap().as_slice();
+assert_eq!(serde_features, &[Value::from("std"), "derive".into()]);
+let regex = deps.get("regex").unwrap().as_str().unwrap();
+assert_eq!(regex, "1.5");
 
 const CARGO_TOML: &'static str = r#"
 [package]

--- a/src/parse/strings.rs
+++ b/src/parse/strings.rs
@@ -23,14 +23,14 @@ pub(crate) fn parse<'i>(input: &mut &'i str) -> PResult<Value<'i>, ContextError>
 /// Parses a basic string value enclosed in quotes.
 pub(crate) fn parse_basic<'i>(input: &mut &'i str) -> PResult<Value<'i>, ContextError> {
     delimited('"', take_until(0.., '"'), '"')
-        .map(|s: &str| Value::String(s.into()))
+        .map(Into::into)
         .parse_next(input)
 }
 
 /// Parses a literal string value enclosed in single quotes.
 pub(crate) fn parse_literal<'i>(input: &mut &'i str) -> PResult<Value<'i>, ContextError> {
     delimited('\'', take_until(0.., '\''), '\'')
-        .map(|s: &str| Value::String(s.into()))
+        .map(Into::into)
         .parse_next(input)
 }
 
@@ -44,7 +44,7 @@ pub(crate) fn parse_multiline_basic<'i>(input: &mut &'i str) -> PResult<Value<'i
         }),
         "\"\"\"",
     )
-    .map(|s| Value::String(s.into()))
+    .map(Into::into)
     .parse_next(input)
 }
 
@@ -55,6 +55,6 @@ pub(crate) fn parse_multiline_literal<'i>(input: &mut &'i str) -> PResult<Value<
         take_until(0.., "'''").map(|s: &str| s.trim_start_matches('\n')), // Trim leading newlines
         "'''",
     )
-    .map(|s| Value::String(s.into()))
+    .map(Into::into)
     .parse_next(input)
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -22,6 +22,79 @@ pub enum Value<'a> {
     Table(Table<'a>),
 }
 
+impl<'a> Value<'a> {
+    /// Returns the underlying `&str` if the `Value` is a string
+    pub fn as_str(&'a self) -> Option<&'a str> {
+        match self {
+            Self::String(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// Returns the underlying `i64` if the `Value` is an integer
+    pub fn as_i64(&self) -> Option<i64> {
+        match self {
+            &Self::Integer(i) => Some(i),
+            _ => None,
+        }
+    }
+
+    /// Returns the underlying `f64` if the `Value` is a float
+    pub fn as_f64(&self) -> Option<f64> {
+        match self {
+            &Self::Float(f) => Some(f),
+            _ => None,
+        }
+    }
+
+    /// Returns the underlying `f64` if the `Value` is a float
+    pub fn as_bool(&self) -> Option<bool> {
+        match self {
+            &Self::Boolean(b) => Some(b),
+            _ => None,
+        }
+    }
+
+    /// Returns the underlying [`Array`] if the `Value` is an array
+    pub fn as_array(&'a self) -> Option<&'a Array<'a>> {
+        match self {
+            Self::Array(a) => Some(a),
+            _ => None,
+        }
+    }
+
+    /// Returns the underlying [`Table`] if the `Value` is a table
+    pub fn as_table(&'a self) -> Option<&'a Table<'a>> {
+        match self {
+            Self::Table(t) => Some(t),
+            _ => None,
+        }
+    }
+}
+
+impl<'a, V> FromIterator<V> for Value<'a>
+where
+    V: Into<Value<'a>>,
+{
+    fn from_iter<I: IntoIterator<Item = V>>(iter: I) -> Self {
+        Value::Array(iter.into_iter().map(|v| v.into()).collect())
+    }
+}
+
+impl<'a, K, V> FromIterator<(K, V)> for Value<'a>
+where
+    K: Into<Cow<'a, str>>,
+    V: Into<Value<'a>>,
+{
+    fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
+        Value::Table(
+            iter.into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
+        )
+    }
+}
+
 macro_rules! impl_from {
     ($ty:ty => $variant:ident) => {
         impl<'a> From<$ty> for Value<'a> {
@@ -34,6 +107,7 @@ macro_rules! impl_from {
 
 impl_from!(Cow<'a, str> => String);
 impl_from!(&'a str => String);
+impl_from!(String => String);
 impl_from!(i64 => Integer);
 impl_from!(f64 => Float);
 impl_from!(bool => Boolean);

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -5,98 +5,68 @@ fn simple_cargo_toml() {
     let mut map = Table::new();
     map.insert(
         "package".into(),
-        Value::Table({
-            let mut package = Table::new();
-            package.insert("name".into(), Value::String("example".into()));
-            package.insert("version".into(), Value::String("0.1.0".into()));
-            package.insert("edition".into(), Value::String("2021".into()));
-            package.insert("resolver".into(), Value::String("2".into()));
-            package.insert(
-                "authors".into(),
-                Value::Array(
-                    [
-                        Value::String("Alice Great <foo@bar.com>".into()),
-                        Value::String("Bob Less".into()),
-                    ]
+        [
+            ("name", "example".into()),
+            ("version", "0.1.0".into()),
+            ("edition", "2021".into()),
+            ("resolver", "2".into()),
+            (
+                "authors",
+                ["Alice Great <foo@bar.com>", "Bob Less"]
                     .into_iter()
-                    .collect(),
-                ),
-            );
-            package
-        }),
+                    .collect::<Value>(),
+            ),
+        ]
+        .into_iter()
+        .collect(),
     );
     map.insert(
         "dependencies".into(),
-        Value::Table({
-            let mut dependencies = Table::new();
-            dependencies.insert(
-                "serde".into(),
-                Value::Table({
-                    let mut serde = Table::new();
-                    serde.insert("version".into(), Value::String("1.0".into()));
-                    serde.insert(
-                        "features".into(),
-                        Value::Array(
-                            [Value::String("std".into()), Value::String("derive".into())]
-                                .into_iter()
-                                .collect(),
-                        ),
-                    );
-                    serde
-                }),
-            );
-            dependencies.insert("regex".into(), Value::String("1.5".into()));
-            dependencies
-        }),
+        [
+            (
+                "serde",
+                [
+                    ("version", "1.0".into()),
+                    ("features", ["std", "derive"].into_iter().collect::<Value>()),
+                ]
+                .into_iter()
+                .collect::<Value>(),
+            ),
+            ("regex", "1.5".into()),
+        ]
+        .into_iter()
+        .collect(),
     );
     map.insert(
         "target".into(),
-        Value::Table({
-            let mut target = Table::new();
-            target.insert(
-                "cfg(unix)".into(),
-                Value::Table({
-                    let mut cfg_unix = Table::new();
-                    cfg_unix.insert(
-                        "build-dependencies".into(),
-                        Value::Table({
-                            let mut build_dependencies = Table::new();
-                            build_dependencies.insert("cc".into(), Value::String("1.0.3".into()));
-
-                            build_dependencies
-                        }),
-                    );
-
-                    cfg_unix
-                }),
-            );
-
-            target
-        }),
+        [(
+            "cfg(unix)",
+            [(
+                "build-dependencies",
+                [("cc", "1.0.3")].into_iter().collect::<Value>(),
+            )]
+            .into_iter()
+            .collect::<Value>(),
+        )]
+        .into_iter()
+        .collect(),
     );
     map.insert(
         "features".into(),
-        Value::Table({
-            let mut features = Table::new();
-            features.insert(
-                "default".into(),
-                Value::Array([Value::String("serde".into())].into_iter().collect()),
-            );
-            features
-        }),
+        [("default", ["serde"].into_iter().collect::<Value>())]
+            .into_iter()
+            .collect(),
     );
     map.insert(
         "bin".into(),
-        Value::Array(
-            [Value::Table({
-                let mut bin = Table::new();
-                bin.insert("name".into(), Value::String("some-binary".into()));
-                bin.insert("path".into(), Value::String("src/bin/my-binary.rs".into()));
-                bin
-            })]
-            .into_iter()
-            .collect(),
-        ),
+        [[
+            ("name", Value::from("some-binary")),
+            ("path", "src/bin/my-binary.rs".into()),
+        ]
+        .into_iter()
+        .collect::<Value>()]
+        .into_iter()
+        .collect(),
     );
 
     let parsed_map = parse(CARGO_TOML).unwrap();


### PR DESCRIPTION
Stemming from https://github.com/zeenix/tomling/pull/23#issue-2703532905

Adds (eliding lifetimes for brevity)

- `Value::as_str(&self) -> Option<&str>`
- `Value::as_i64(&self) -> Option<i64>`
- `Value::as_f64(&self) -> Option<f64>`
- `Value::as_bool(&self) -> Option<bool>`
- `Value::as_array(&self) -> Option<&Array>`
- `Value::as_table(&self) -> Option<&Table>`
- `impl From<X> for Value`
  - `String`
  - `&str`
  - `Cow<str>`
  - `i64`
  - `f64`
  - `bool`
  - `Array`
  - `Table`
- `impl<V: Into<Value>> FromIterator<V> for Value` (arrays)
- `impl<K: Into<Cow<str>>, V: Into<Value>> FromIterator<(K, V)> for Value` (tables)

There's a decent loc reduction, but also significant line-noise reduction in the tests that were manually constructing `Value`s

---

I briefly started adding `PartialEq<T>` impls for `Value`, but then I quickly realized just how many different combinations would be required to cover all the common cases, and instead I noped out and leaned into the conversion helpers more