### PR TITLE
Handle escape sequences in basic and multiline basic strings

### DIFF
--- a/src/parse/strings.rs
+++ b/src/parse/strings.rs
@@ -1,16 +1,14 @@
 use crate::Value;
 
 use winnow::{
-    combinator::{alt, delimited},
+    combinator::{alt, delimited, preceded},
     error::ContextError,
-    token::take_until,
+    token::{take_until, take_while},
     PResult, Parser,
 };
 
 /// Parses a string value enclosed in quotes
 pub(crate) fn parse<'i>(input: &mut &'i str) -> PResult<Value<'i>, ContextError> {
-    // TODO:
-    // * Handle escape sequences.
     alt((
         parse_multiline_basic,
         parse_basic,
@@ -22,9 +20,33 @@ pub(crate) fn parse<'i>(input: &mut &'i str) -> PResult<Value<'i>, ContextError>
 
 /// Parses a basic string value enclosed in quotes.
 pub(crate) fn parse_basic<'i>(input: &mut &'i str) -> PResult<Value<'i>, ContextError> {
-    delimited('"', take_until(0.., '"'), '"')
+    delimited('"', parse_basic_inner, '"')
         .map(Into::into)
         .parse_next(input)
+}
+
+fn parse_basic_inner<'i>(input: &mut &'i str) -> PResult<&'i str, ContextError> {
+    take_while(0.., |c| c != '\\' && c != '"')
+        .and_then(alt((
+            preceded('\\', parse_escape_sequence),
+            take_while(0.., |c| c != '\\' && c != '"'),
+        )))
+        .parse_next(input)
+}
+
+fn parse_escape_sequence<'i>(input: &mut &'i str) -> PResult<&'i str, ContextError> {
+    alt((
+        "\\\"".value("\""),
+        "\\\\".value("\\"),
+        "\\b".value("\x08"),
+        "\\t".value("\t"),
+        "\\n".value("\n"),
+        "\\f".value("\x0C"),
+        "\\r".value("\r"),
+        preceded("\\u", take_while(4, |c: char| c.is_ascii_hexdigit())),
+        preceded("\\U", take_while(8, |c: char| c.is_ascii_hexdigit())),
+    ))
+    .parse_next(input)
 }
 
 /// Parses a literal string value enclosed in single quotes.
@@ -38,7 +60,7 @@ pub(crate) fn parse_literal<'i>(input: &mut &'i str) -> PResult<Value<'i>, Conte
 pub(crate) fn parse_multiline_basic<'i>(input: &mut &'i str) -> PResult<Value<'i>, ContextError> {
     delimited(
         "\"\"\"",
-        take_until(0.., "\"\"\"").map(|s: &str| {
+        parse_multiline_basic_inner.map(|s: &str| {
             // Trim leading newlines.
             s.trim_start_matches('\n')
         }),
@@ -46,6 +68,15 @@ pub(crate) fn parse_multiline_basic<'i>(input: &mut &'i str) -> PResult<Value<'i
     )
     .map(Into::into)
     .parse_next(input)
+}
+
+fn parse_multiline_basic_inner<'i>(input: &mut &'i str) -> PResult<&'i str, ContextError> {
+    take_while(0.., |c| c != '\\' && c != '"')
+        .and_then(alt((
+            preceded('\\', parse_escape_sequence),
+            take_while(0.., |c| c != '\\' && c != '"'),
+        )))
+        .parse_next(input)
 }
 
 /// Parses a literal multiline string value enclosed in triple single quotes (`'''`).

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -160,6 +160,116 @@ fn simple_cargo_toml_serde() {
     assert_eq!(binary.path(), Some("src/bin/my-binary.rs"));
 }
 
+#[test]
+fn test_escape_sequences_basic_strings() {
+    use tomling::parse;
+
+    let toml_str = r#"
+        str1 = "This is a backslash: \\"
+        str2 = "This is a double quote: \""
+        str3 = "This is a backspace: \b"
+        str4 = "This is a tab: \t"
+        str5 = "This is a newline: \n"
+        str6 = "This is a form feed: \f"
+        str7 = "This is a carriage return: \r"
+        str8 = "This is a unicode character: \u0041"
+        str9 = "This is another unicode character: \U00000041"
+    "#;
+
+    let parsed_map = parse(toml_str).unwrap();
+    assert_eq!(
+        parsed_map.get("str1").unwrap().as_str().unwrap(),
+        "This is a backslash: \\"
+    );
+    assert_eq!(
+        parsed_map.get("str2").unwrap().as_str().unwrap(),
+        "This is a double quote: \""
+    );
+    assert_eq!(
+        parsed_map.get("str3").unwrap().as_str().unwrap(),
+        "This is a backspace: \x08"
+    );
+    assert_eq!(
+        parsed_map.get("str4").unwrap().as_str().unwrap(),
+        "This is a tab: \t"
+    );
+    assert_eq!(
+        parsed_map.get("str5").unwrap().as_str().unwrap(),
+        "This is a newline: \n"
+    );
+    assert_eq!(
+        parsed_map.get("str6").unwrap().as_str().unwrap(),
+        "This is a form feed: \x0C"
+    );
+    assert_eq!(
+        parsed_map.get("str7").unwrap().as_str().unwrap(),
+        "This is a carriage return: \r"
+    );
+    assert_eq!(
+        parsed_map.get("str8").unwrap().as_str().unwrap(),
+        "This is a unicode character: A"
+    );
+    assert_eq!(
+        parsed_map.get("str9").unwrap().as_str().unwrap(),
+        "This is another unicode character: A"
+    );
+}
+
+#[test]
+fn test_escape_sequences_multiline_basic_strings() {
+    use tomling::parse;
+
+    let toml_str = r#"
+        str1 = """This is a backslash: \\"""
+        str2 = """This is a double quote: \"""""
+        str3 = """This is a backspace: \b"""
+        str4 = """This is a tab: \t"""
+        str5 = """This is a newline: \n"""
+        str6 = """This is a form feed: \f"""
+        str7 = """This is a carriage return: \r"""
+        str8 = """This is a unicode character: \u0041"""
+        str9 = """This is another unicode character: \U00000041"""
+    "#;
+
+    let parsed_map = parse(toml_str).unwrap();
+    assert_eq!(
+        parsed_map.get("str1").unwrap().as_str().unwrap(),
+        "This is a backslash: \\"
+    );
+    assert_eq!(
+        parsed_map.get("str2").unwrap().as_str().unwrap(),
+        "This is a double quote: \""
+    );
+    assert_eq!(
+        parsed_map.get("str3").unwrap().as_str().unwrap(),
+        "This is a backspace: \x08"
+    );
+    assert_eq!(
+        parsed_map.get("str4").unwrap().as_str().unwrap(),
+        "This is a tab: \t"
+    );
+    assert_eq!(
+        parsed_map.get("str5").unwrap().as_str().unwrap(),
+        "This is a newline: \n"
+    );
+    assert_eq!(
+        parsed_map.get("str6").unwrap().as_str().unwrap(),
+        "This is a form feed: \x0C"
+    );
+    assert_eq!(
+        parsed_map.get("str7").unwrap().as_str().unwrap(),
+        "This is a carriage return: \r"
+    );
+    assert_eq!(
+        parsed_map.get("str8").unwrap().as_str().unwrap(),
+        "This is a unicode character: A"
+    );
+    assert_eq!(
+        parsed_map.get("str9").unwrap().as_str().unwrap(),
+        "This is another unicode character: A"
+    );
+}
+
 const CARGO_TOML: &str = r#"
 [package]
 name = "example"


### PR DESCRIPTION
Fixes #37

Implement escape sequence handling in basic and multiline basic strings.

* **src/parse/strings.rs**
  - Add `parse_basic_inner` function to handle escape sequences in basic strings.
  - Add `parse_escape_sequence` function to handle specific escape sequences.
  - Modify `parse_basic` function to use `parse_basic_inner`.
  - Add `parse_multiline_basic_inner` function to handle escape sequences in multiline basic strings.
  - Modify `parse_multiline_basic` function to use `parse_multiline_basic_inner`.

* **tests/simple.rs**
  - Add test cases for escape sequences in basic strings.
  - Add test cases for escape sequences in multiline basic strings.

---

Note: PR template generated using Copilot Workspace. Trying it out..

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zeenix/tomling/pull/38?shareId=ad40640a-4ee5-46ce-9a2a-c37eba674acb).