### PR TITLE
🚑️  Require winnow 0.6.24 in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ simd = ["winnow/simd"]
 std = ["winnow/std", "serde?/std"]
 
 [dependencies]
-winnow = { version = "0.6.20", default-features = false, features = ["alloc"] }
+winnow = { version = "0.6.24", default-features = false, features = ["alloc"] }
 serde = { version = "1.0.215", default-features = false, optional = true, features = [
     "derive",
     "alloc",


### PR DESCRIPTION
Forgotten fix from 19e72b72294a7ef0276bd731eeda0fc6499f4eaa.